### PR TITLE
Convert error types in try_stream! try

### DIFF
--- a/async-stream-impl/src/lib.rs
+++ b/async-stream-impl/src/lib.rs
@@ -89,7 +89,7 @@ impl VisitMut for Scrub {
                     match #e {
                         Ok(v) => v,
                         Err(e) => {
-                            __yield_tx.send(Err(e)).await;
+                            __yield_tx.send(Err(e.into())).await;
                             return;
                         }
                     }

--- a/async-stream/tests/try_stream.rs
+++ b/async-stream/tests/try_stream.rs
@@ -32,3 +32,30 @@ async fn yield_then_err() {
     assert_eq!(Ok("hello"), values[0]);
     assert_eq!(Err("world"), values[1]);
 }
+
+#[tokio::test]
+async fn convert_err() {
+    struct ErrorA(u8);
+    #[derive(PartialEq, Debug)]
+    struct ErrorB(u8);
+    impl From<ErrorA> for ErrorB {
+        fn from(a: ErrorA) -> ErrorB {
+            ErrorB(a.0)
+        }
+    }
+
+    fn test() -> impl Stream<Item = Result<&'static str, ErrorB>> {
+        try_stream! {
+            if true {
+                Err(ErrorA(1))?;
+            } else {
+                Err(ErrorB(2))?;
+            }
+            yield "unreachable";
+        }
+    }
+
+    let values: Vec<_> = test().collect().await;
+    assert_eq!(1, values.len());
+    assert_eq!(Err(ErrorB(1)), values[0]);
+}


### PR DESCRIPTION
Bring `try_stream! { ...? }` closer to the usual `?` operator by
converting the error type via `From`.

Fixes #11