### PR TITLE
Support reexporting from anywhere by wrapping in a declarative macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,6 @@
 members = [
     "async-stream",
     "async-stream-impl",
+    "async-stream/tests/reexporter",
+    "async-stream/tests/test-reexport",
 ]

--- a/async-stream-impl/src/lib.rs
+++ b/async-stream-impl/src/lib.rs
@@ -1,32 +1,40 @@
 use proc_macro::TokenStream;
 use proc_macro2::{Group, TokenStream as TokenStream2, TokenTree};
 use quote::quote;
+use syn::parse::Parser;
 use syn::visit_mut::VisitMut;
 
-struct Scrub {
+struct Scrub<'a> {
     /// Whether the stream is a try stream.
     is_try: bool,
     /// The unit expression, `()`.
     unit: Box<syn::Expr>,
     has_yielded: bool,
+    crate_path: &'a TokenStream2,
 }
 
-fn parse_input(input: TokenStream) -> syn::Result<Vec<syn::Stmt>> {
-    let input = replace_for_await(input.into());
-    Ok(syn::parse::Parser::parse2(syn::Block::parse_within, input)?)
+fn parse_input(input: TokenStream) -> syn::Result<(TokenStream2, Vec<syn::Stmt>)> {
+    let mut input = TokenStream2::from(input).into_iter();
+    let crate_path = match input.next().unwrap() {
+        TokenTree::Group(group) => group.stream(),
+        _ => panic!(),
+    };
+    let stmts = syn::Block::parse_within.parse2(replace_for_await(input))?;
+    Ok((crate_path, stmts))
 }
 
-impl Scrub {
-    fn new(is_try: bool) -> Self {
+impl<'a> Scrub<'a> {
+    fn new(is_try: bool, crate_path: &'a TokenStream2) -> Self {
         Self {
             is_try,
             unit: syn::parse_quote!(()),
             has_yielded: false,
+            crate_path,
         }
     }
 }
 
-impl VisitMut for Scrub {
+impl VisitMut for Scrub<'_> {
     fn visit_expr_mut(&mut self, i: &mut syn::Expr) {
         match i {
             syn::Expr::Yield(yield_expr) => {
@@ -37,7 +45,7 @@ impl VisitMut for Scrub {
                 // let ident = &self.yielder;
 
                 *i = if self.is_try {
-                    syn::parse_quote! { __yield_tx.send(Ok(#value_expr)).await }
+                    syn::parse_quote! { __yield_tx.send(::core::result::Result::Ok(#value_expr)).await }
                 } else {
                     syn::parse_quote! { __yield_tx.send(#value_expr).await }
                 };
@@ -49,9 +57,9 @@ impl VisitMut for Scrub {
 
                 *i = syn::parse_quote! {
                     match #e {
-                        Ok(v) => v,
-                        Err(e) => {
-                            __yield_tx.send(Err(e.into())).await;
+                        ::core::result::Result::Ok(v) => v,
+                        ::core::result::Result::Err(e) => {
+                            __yield_tx.send(::core::result::Result::Err(e.into())).await;
                             return;
                         }
                     }
@@ -81,6 +89,7 @@ impl VisitMut for Scrub {
                     return;
                 }
 
+                let crate_path = self.crate_path;
                 *i = syn::parse_quote! {{
                     let mut __pinned = #expr;
                     let mut __pinned = unsafe {
@@ -88,7 +97,7 @@ impl VisitMut for Scrub {
                     };
                     #label
                     loop {
-                        let #pat = match ::async_stream::reexport::next(&mut __pinned).await {
+                        let #pat = match #crate_path::reexport::next(&mut __pinned).await {
                             ::core::option::Option::Some(e) => e,
                             ::core::option::Option::None => break,
                         };
@@ -105,43 +114,19 @@ impl VisitMut for Scrub {
     }
 }
 
-/// Asynchronous stream
-///
-/// See [crate](index.html) documentation for more details.
-///
-/// # Examples
-///
-/// ```rust
-/// use async_stream::stream;
-///
-/// use futures_util::pin_mut;
-/// use futures_util::stream::StreamExt;
-///
-/// #[tokio::main]
-/// async fn main() {
-///     let s = stream! {
-///         for i in 0..3 {
-///             yield i;
-///         }
-///     };
-///
-///     pin_mut!(s); // needed for iteration
-///
-///     while let Some(value) = s.next().await {
-///         println!("got {}", value);
-///     }
-/// }
-/// ```
+/// The first token tree in the stream must be a group containing the path to the `async-stream`
+/// crate.
 #[proc_macro]
-pub fn stream(input: TokenStream) -> TokenStream {
-    let mut stmts = match parse_input(input) {
+#[doc(hidden)]
+pub fn stream_inner(input: TokenStream) -> TokenStream {
+    let (crate_path, mut stmts) = match parse_input(input) {
         Ok(x) => x,
         Err(e) => return e.to_compile_error().into(),
     };
 
-    let mut scrub = Scrub::new(false);
+    let mut scrub = Scrub::new(false, &crate_path);
 
-    for mut stmt in &mut stmts[..] {
+    for mut stmt in &mut stmts {
         scrub.visit_stmt_mut(&mut stmt);
     }
 
@@ -154,8 +139,8 @@ pub fn stream(input: TokenStream) -> TokenStream {
     };
 
     quote!({
-        let (mut __yield_tx, __yield_rx) = ::async_stream::yielder::pair();
-        ::async_stream::AsyncStream::new(__yield_rx, async move {
+        let (mut __yield_tx, __yield_rx) = #crate_path::yielder::pair();
+        #crate_path::AsyncStream::new(__yield_rx, async move {
             #dummy_yield
             #(#stmts)*
         })
@@ -163,45 +148,19 @@ pub fn stream(input: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Asynchronous fallible stream
-///
-/// See [crate](index.html) documentation for more details.
-///
-/// # Examples
-///
-/// ```rust
-/// use tokio::net::{TcpListener, TcpStream};
-///
-/// use async_stream::try_stream;
-/// use futures_core::stream::Stream;
-///
-/// use std::io;
-/// use std::net::SocketAddr;
-///
-/// fn bind_and_accept(addr: SocketAddr)
-///     -> impl Stream<Item = io::Result<TcpStream>>
-/// {
-///     try_stream! {
-///         let mut listener = TcpListener::bind(addr).await?;
-///
-///         loop {
-///             let (stream, addr) = listener.accept().await?;
-///             println!("received on {:?}", addr);
-///             yield stream;
-///         }
-///     }
-/// }
-/// ```
+/// The first token tree in the stream must be a group containing the path to the `async-stream`
+/// crate.
 #[proc_macro]
-pub fn try_stream(input: TokenStream) -> TokenStream {
-    let mut stmts = match parse_input(input) {
+#[doc(hidden)]
+pub fn try_stream_inner(input: TokenStream) -> TokenStream {
+    let (crate_path, mut stmts) = match parse_input(input) {
         Ok(x) => x,
         Err(e) => return e.to_compile_error().into(),
     };
 
-    let mut scrub = Scrub::new(true);
+    let mut scrub = Scrub::new(true, &crate_path);
 
-    for mut stmt in &mut stmts[..] {
+    for mut stmt in &mut stmts {
         scrub.visit_stmt_mut(&mut stmt);
     }
 
@@ -214,8 +173,8 @@ pub fn try_stream(input: TokenStream) -> TokenStream {
     };
 
     quote!({
-        let (mut __yield_tx, __yield_rx) = ::async_stream::yielder::pair();
-        ::async_stream::AsyncStream::new(__yield_rx, async move {
+        let (mut __yield_tx, __yield_rx) = #crate_path::yielder::pair();
+        #crate_path::AsyncStream::new(__yield_rx, async move {
             #dummy_yield
             #(#stmts)*
         })
@@ -223,7 +182,8 @@ pub fn try_stream(input: TokenStream) -> TokenStream {
     .into()
 }
 
-fn replace_for_await(input: TokenStream2) -> TokenStream2 {
+/// Replace `for await` with `#[await] for`, which will be later transformed into a `next` loop.
+fn replace_for_await(input: impl IntoIterator<Item = TokenTree>) -> TokenStream2 {
     let mut input = input.into_iter().peekable();
     let mut tokens = Vec::new();
 

--- a/async-stream/src/lib.rs
+++ b/async-stream/src/lib.rs
@@ -162,11 +162,82 @@ mod next;
 #[doc(hidden)]
 pub mod yielder;
 
-// Used by the macro, but not intended to be accessed publically.
+// Used by the macro, but not intended to be accessed publicly.
 #[doc(hidden)]
 pub use crate::async_stream::AsyncStream;
 
-pub use async_stream_impl::{stream, try_stream};
+#[doc(hidden)]
+pub use async_stream_impl;
+
+/// Asynchronous stream
+///
+/// See [crate](index.html) documentation for more details.
+///
+/// # Examples
+///
+/// ```
+/// use async_stream::stream;
+///
+/// use futures_util::pin_mut;
+/// use futures_util::stream::StreamExt;
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let s = stream! {
+///         for i in 0..3 {
+///             yield i;
+///         }
+///     };
+///
+///     pin_mut!(s); // needed for iteration
+///
+///     while let Some(value) = s.next().await {
+///         println!("got {}", value);
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! stream {
+    ($($tt:tt)*) => {
+        $crate::async_stream_impl::stream_inner!(($crate) $($tt)*)
+    }
+}
+
+/// Asynchronous fallible stream
+///
+/// See [crate](index.html) documentation for more details.
+///
+/// # Examples
+///
+/// ```
+/// use tokio::net::{TcpListener, TcpStream};
+///
+/// use async_stream::try_stream;
+/// use futures_core::stream::Stream;
+///
+/// use std::io;
+/// use std::net::SocketAddr;
+///
+/// fn bind_and_accept(addr: SocketAddr)
+///     -> impl Stream<Item = io::Result<TcpStream>>
+/// {
+///     try_stream! {
+///         let mut listener = TcpListener::bind(addr).await?;
+///
+///         loop {
+///             let (stream, addr) = listener.accept().await?;
+///             println!("received on {:?}", addr);
+///             yield stream;
+///         }
+///     }
+/// }
+/// ```
+#[macro_export]
+macro_rules! try_stream {
+    ($($tt:tt)*) => {
+        $crate::async_stream_impl::try_stream_inner!(($crate) $($tt)*)
+    }
+}
 
 #[doc(hidden)]
 pub mod reexport {

--- a/async-stream/tests/reexporter/Cargo.toml
+++ b/async-stream/tests/reexporter/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "reexporter"
+version = "0.0.0"
+authors = []
+edition = "2018"
+publish = false
+
+[dependencies]
+async-stream = { path = "../.." }

--- a/async-stream/tests/reexporter/src/lib.rs
+++ b/async-stream/tests/reexporter/src/lib.rs
@@ -1,0 +1,3 @@
+//! A crate to test reexporting the `stream!` and `try_stream!` macros.
+
+pub use async_stream::{stream, try_stream};

--- a/async-stream/tests/test-reexport/Cargo.toml
+++ b/async-stream/tests/test-reexport/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "test-reexport"
+version = "0.0.0"
+authors = []
+edition = "2018"
+publish = false
+
+[dependencies]
+reexporter = { path = "../reexporter" }
+futures-core = "0.3.8"

--- a/async-stream/tests/test-reexport/src/lib.rs
+++ b/async-stream/tests/test-reexport/src/lib.rs
@@ -1,0 +1,17 @@
+use futures_core::stream::Stream;
+
+pub fn create_stream() -> impl Stream<Item = u8> {
+    reexporter::stream! {
+        for x in 0..10_u8 {
+            yield x;
+        }
+    }
+}
+
+pub fn create_try_stream() -> impl Stream<Item = Result<u8, u8>> {
+    reexporter::try_stream! {
+        for x in 0..10_u8 {
+            yield x;
+        }
+    }
+}

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -23,6 +23,8 @@ error[E0271]: type mismatch resolving `<[static generator@$DIR/src/lib.rs:202:9:
 9  | |         let v = f.await;
 10 | |     };
    | |______^ expected `()`, found integer
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0698]: type inside `async` block must be known in this context
  --> $DIR/yield_in_async.rs:6:19
@@ -71,6 +73,3 @@ note: the type is part of the `async` block because of this `await`
   |
 9 |         let v = f.await;
   |                 ^^^^^^^
-
-Some errors have detailed explanations: E0271, E0658, E0698, E0727.
-For more information about an error, try `rustc --explain E0271`.

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -23,13 +23,6 @@ error[E0271]: type mismatch resolving `<[static generator@$DIR/src/lib.rs:202:9:
 9  | |         let v = f.await;
 10 | |     };
    | |______^ expected `()`, found integer
-   |
-  ::: $RUST/core/src/future/mod.rs
-   |
-   |       T: Generator<ResumeTy, Yield = ()>,
-   |                              ---------- required by this bound in `from_generator`
-   |
-   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0698]: type inside `async` block must be known in this context
  --> $DIR/yield_in_async.rs:6:19
@@ -78,3 +71,6 @@ note: the type is part of the `async` block because of this `await`
   |
 9 |         let v = f.await;
   |                 ^^^^^^^
+
+Some errors have detailed explanations: E0271, E0658, E0698, E0727.
+For more information about an error, try `rustc --explain E0271`.

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -12,7 +12,7 @@ error[E0727]: `async` generators are not yet supported
 6 |             yield 123;
   |             ^^^^^^^^^
 
-error[E0271]: type mismatch resolving `<[static generator@$DIR/tests/ui/yield_in_async.rs:4:5: 10:7 _] as Generator<ResumeTy>>::Yield == ()`
+error[E0271]: type mismatch resolving `<[static generator@$DIR/src/lib.rs:212:9: 212:67 _] as Generator<ResumeTy>>::Yield == ()`
   --> $DIR/yield_in_async.rs:4:5
    |
 4  | /     stream! {
@@ -28,6 +28,8 @@ error[E0271]: type mismatch resolving `<[static generator@$DIR/tests/ui/yield_in
    |
    |       T: Generator<ResumeTy, Yield = ()>,
    |                              ---------- required by this bound in `from_generator`
+   |
+   = note: this error originates in a macro (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0698]: type inside `async` block must be known in this context
  --> $DIR/yield_in_async.rs:6:19

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -12,7 +12,7 @@ error[E0727]: `async` generators are not yet supported
 6 |             yield 123;
   |             ^^^^^^^^^
 
-error[E0271]: type mismatch resolving `<[static generator@$DIR/src/lib.rs:212:9: 212:67 _] as Generator<ResumeTy>>::Yield == ()`
+error[E0271]: type mismatch resolving `<[static generator@$DIR/src/lib.rs:202:9: 202:67 _] as Generator<ResumeTy>>::Yield == ()`
   --> $DIR/yield_in_async.rs:4:5
    |
 4  | /     stream! {

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -23,6 +23,11 @@ error[E0271]: type mismatch resolving `<[static generator@$DIR/tests/ui/yield_in
 9  | |         let v = f.await;
 10 | |     };
    | |______^ expected `()`, found integer
+   |
+  ::: $RUST/core/src/future/mod.rs
+   |
+   |       T: Generator<ResumeTy, Yield = ()>,
+   |                              ---------- required by this bound in `from_generator`
 
 error[E0698]: type inside `async` block must be known in this context
  --> $DIR/yield_in_async.rs:6:19
@@ -71,6 +76,3 @@ note: the type is part of the `async` block because of this `await`
   |
 9 |         let v = f.await;
   |                 ^^^^^^^
-
-Some errors have detailed explanations: E0271, E0658, E0698, E0727.
-For more information about an error, try `rustc --explain E0271`.

--- a/async-stream/tests/ui/yield_in_closure.stderr
+++ b/async-stream/tests/ui/yield_in_closure.stderr
@@ -6,10 +6,10 @@ error[E0658]: yield syntax is experimental
   |
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
-error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:212:9: 212:67 _]`
+error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:202:9: 202:67 _]`
  --> $DIR/yield_in_closure.rs:6:14
   |
 6 |             .and_then(|v| {
-  |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:212:9: 212:67 _]`
+  |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:202:9: 202:67 _]`
   |
-  = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/src/lib.rs:212:9: 212:67 _]`
+  = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/src/lib.rs:202:9: 202:67 _]`

--- a/async-stream/tests/ui/yield_in_closure.stderr
+++ b/async-stream/tests/ui/yield_in_closure.stderr
@@ -13,3 +13,6 @@ error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/l
   |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:202:9: 202:67 _]`
   |
   = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/src/lib.rs:202:9: 202:67 _]`
+
+Some errors have detailed explanations: E0277, E0658.
+For more information about an error, try `rustc --explain E0277`.

--- a/async-stream/tests/ui/yield_in_closure.stderr
+++ b/async-stream/tests/ui/yield_in_closure.stderr
@@ -6,13 +6,10 @@ error[E0658]: yield syntax is experimental
   |
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
-error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:4:5: 10:7 _]`
+error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:212:9: 212:67 _]`
  --> $DIR/yield_in_closure.rs:6:14
   |
 6 |             .and_then(|v| {
-  |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:4:5: 10:7 _]`
+  |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:212:9: 212:67 _]`
   |
-  = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/tests/ui/yield_in_closure.rs:4:5: 10:7 _]`
-
-Some errors have detailed explanations: E0277, E0658.
-For more information about an error, try `rustc --explain E0277`.
+  = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/src/lib.rs:212:9: 212:67 _]`


### PR DESCRIPTION
This PR allows the `stream!` and `try_stream!` macros to be reexported from anywhere by having the procedural macro take a path to `async_stream`, and having the macros in `async-stream` be declarative macros that wrap the procedural ones and pass in `$crate`.