### PR TITLE
Add note on Rust version requirement

### DIFF
--- a/async-stream/README.md
+++ b/async-stream/README.md
@@ -150,6 +150,9 @@ caller.
 
 [`Stream`]: https://docs.rs/futures-core/*/futures_core/stream/trait.Stream.html
 
+## Supported Rust Versions
+`async-stream` is built against the latest stable release. The minimum supported version is 1.45 due to [function-like procedural macros.. in expression, pattern, and statement positions](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1450-2020-07-16).
+
 ## License
 
 This project is licensed under the [MIT license](LICENSE).

--- a/async-stream/README.md
+++ b/async-stream/README.md
@@ -151,7 +151,7 @@ caller.
 [`Stream`]: https://docs.rs/futures-core/*/futures_core/stream/trait.Stream.html
 
 ## Supported Rust Versions
-`async-stream` is built against the latest stable release. The minimum supported version is 1.45 due to [function-like procedural macros.. in expression, pattern, and statement positions](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1450-2020-07-16).
+`async-stream` is built against the latest stable release. The minimum supported version is 1.45 due to [function-like procedural macros in expression, pattern, and statement positions](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#stabilizing-function-like-procedural-macros-in-expressions-patterns-and-statements).
 
 ## License
 


### PR DESCRIPTION
On versions prior to 1.45, the compiler would error with `procedural macros cannot be expanded to statements`.