### PR TITLE
Allow yielding !Unpin values.

### DIFF
--- a/async-stream/src/yielder.rs
+++ b/async-stream/src/yielder.rs
@@ -33,7 +33,7 @@ thread_local!(static STORE: Cell<*mut ()> = Cell::new(ptr::null_mut()));
 
 // ===== impl Sender =====
 
-impl<T: Unpin> Sender<T> {
+impl<T> Sender<T> {
     pub fn send(&mut self, value: T) -> impl Future<Output = ()> {
         Send { value: Some(value) }
     }
@@ -43,7 +43,9 @@ struct Send<T> {
     value: Option<T>,
 }
 
-impl<T: Unpin> Future for Send<T> {
+impl<T> Unpin for Send<T> {}
+
+impl<T> Future for Send<T> {
     type Output = ();
 
     fn poll(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<()> {

--- a/async-stream/tests/stream.rs
+++ b/async-stream/tests/stream.rs
@@ -158,6 +158,20 @@ async fn stream_in_stream() {
     assert_eq!(3, values.len());
 }
 
+#[tokio::test]
+async fn yield_non_unpin_value() {
+    let s: Vec<_> = stream! {
+        for i in 0..3 {
+            yield async move { i };
+        }
+    }
+    .buffered(1)
+    .collect()
+    .await;
+
+    assert_eq!(s, vec![0, 1, 2]);
+}
+
 #[test]
 fn test() {
     let t = trybuild::TestCases::new();


### PR DESCRIPTION
There is no need to require `T: Unpin` as the value being yielded is not behind a Pin.

I added a test with a sample usecase for this, but it's also helpful in generic contexts where yielded values aren't necessarily known to be `Unpin` (even though they are in practice).