### PR TITLE
Disambiguate which proc_macro import to use

### DIFF
--- a/async-stream-impl/src/lib.rs
+++ b/async-stream-impl/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate proc_macro;
 use proc_macro::TokenStream;
 use proc_macro2::{Group, TokenStream as TokenStream2, TokenTree};
 use quote::quote;


### PR DESCRIPTION
If the syn crate is used with full features, compiling
async-stream results in an error.

error[E0432]: unresolved import `proc_macro`
 --> external/rust/crates/async-stream-impl/src/lib.rs:1:5
  |
1 | use proc_macro::TokenStream;
  |     ^^^^^^^^^^ help: a similar path exists: `syn::proc_macro`

error: aborting due to previous error

This error can be avoided by being explicit about which proc_macro
import to use.