### PR TITLE
Expand 'yield' in internal macro calls.

### DIFF
--- a/async-stream/tests/stream.rs
+++ b/async-stream/tests/stream.rs
@@ -81,6 +81,25 @@ async fn yield_multi_value() {
 }
 
 #[tokio::test]
+async fn yield_with_select() {
+    use tokio::select;
+
+    async fn do_stuff_async() {}
+    async fn more_async_work() {}
+
+    let s = stream! {
+        select! {
+            _ = do_stuff_async() => yield "hey",
+            _ = more_async_work() => yield "hey",
+            else => yield "hey",
+        }
+    };
+
+    let values: Vec<_> = s.collect().await;
+    assert_eq!(values, vec!["hey"]);
+}
+
+#[tokio::test]
 async fn return_stream() {
     fn build_stream() -> impl Stream<Item = u32> {
         stream! {

--- a/async-stream/tests/stream.rs
+++ b/async-stream/tests/stream.rs
@@ -81,6 +81,23 @@ async fn yield_multi_value() {
 }
 
 #[tokio::test]
+async fn unit_yield_in_select() {
+    use tokio::select;
+
+    async fn do_stuff_async() {}
+
+    let s = stream! {
+        select! {
+            _ = do_stuff_async() => yield,
+            else => yield,
+        }
+    };
+
+    let values: Vec<_> = s.collect().await;
+    assert_eq!(values.len(), 1);
+}
+
+#[tokio::test]
 async fn yield_with_select() {
     use tokio::select;
 

--- a/async-stream/tests/stream.rs
+++ b/async-stream/tests/stream.rs
@@ -209,6 +209,27 @@ async fn yield_non_unpin_value() {
 }
 
 #[test]
+fn inner_try_stream() {
+    use async_stream::try_stream;
+    use tokio::select;
+
+    async fn do_stuff_async() {}
+
+    let _ = stream! {
+        select! {
+            _ = do_stuff_async() => {
+                let another_s = try_stream! {
+                    yield;
+                };
+                let _: Result<(), ()> = Box::pin(another_s).next().await.unwrap();
+            },
+            else => {},
+        }
+        yield
+    };
+}
+
+#[test]
 fn test() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");

--- a/async-stream/tests/ui/yield_bad_expr_in_macro.rs
+++ b/async-stream/tests/ui/yield_bad_expr_in_macro.rs
@@ -1,0 +1,11 @@
+use async_stream::stream;
+
+fn main() {
+    async fn work() {}
+
+    stream! {
+        tokio::select! {
+            _ = work() => yield fn f() {},
+        }
+    };
+}

--- a/async-stream/tests/ui/yield_bad_expr_in_macro.stderr
+++ b/async-stream/tests/ui/yield_bad_expr_in_macro.stderr
@@ -1,0 +1,5 @@
+error: expected expression
+ --> $DIR/yield_bad_expr_in_macro.rs:8:33
+  |
+8 |             _ = work() => yield fn f() {},
+  |                                 ^^


### PR DESCRIPTION
Resolves #27.

As in the title.