### PR TITLE
Prepare v0.3.2 release

### DIFF
--- a/async-stream-impl/Cargo.toml
+++ b/async-stream-impl/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "async-stream-impl"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "proc macros for async-stream crate"
-documentation = "https://docs.rs/async-stream-impl/0.3"
+documentation = "https://docs.rs/async-stream-impl"
 homepage = "https://github.com/tokio-rs/async-stream"
 repository = "https://github.com/tokio-rs/async-stream"
 

--- a/async-stream/CHANGELOG.md
+++ b/async-stream/CHANGELOG.md
@@ -1,0 +1,14 @@
+# 0.3.2
+
+* Expand `yield` in internal macro calls (#57)
+
+# 0.3.1
+
+* Support reexporting (#46)
+* Allow yielding `!Unpin` values (#50)
+* Implement `Stream::size_hint` method on `AsyncStream` (#40)
+* Documentation improvements
+
+# 0.3.0
+
+* Remove proc-macro-hack (#30)

--- a/async-stream/Cargo.toml
+++ b/async-stream/Cargo.toml
@@ -2,25 +2,21 @@
 name = "async-stream"
 # When releasing to crates.io:
 # - Update version number
-#   - lib.rs: html_root_url.
 #   - README.md
 # - Update CHANGELOG.md
-# - Update doc URL.
-#   - Cargo.toml
-#   - README.md
 # - Create git tag
-version = "0.3.1"
+version = "0.3.2"
 edition = "2018"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "Asynchronous streams using async & await notation"
-documentation = "https://docs.rs/async-stream/0.3"
+documentation = "https://docs.rs/async-stream"
 homepage = "https://github.com/tokio-rs/async-stream"
 repository = "https://github.com/tokio-rs/async-stream"
 readme = "README.md"
 
 [dependencies]
-async-stream-impl = { version = "=0.3.1", path = "../async-stream-impl" }
+async-stream-impl = { version = "=0.3.2", path = "../async-stream-impl" }
 futures-core = "0.3"
 
 [dev-dependencies]

--- a/async-stream/src/lib.rs
+++ b/async-stream/src/lib.rs
@@ -1,4 +1,3 @@
-#![doc(html_root_url = "https://docs.rs/async-stream/0.3.1")]
 #![warn(
     missing_debug_implementations,
     missing_docs,

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -12,7 +12,7 @@ error[E0727]: `async` generators are not yet supported
 6 |             yield 123;
   |             ^^^^^^^^^
 
-error[E0271]: type mismatch resolving `<[static generator@$DIR/src/lib.rs:202:9: 202:67] as Generator<ResumeTy>>::Yield == ()`
+error[E0271]: type mismatch resolving `<[static generator@$DIR/src/lib.rs:201:9: 201:67] as Generator<ResumeTy>>::Yield == ()`
   --> $DIR/yield_in_async.rs:4:5
    |
 4  | /     stream! {

--- a/async-stream/tests/ui/yield_in_closure.stderr
+++ b/async-stream/tests/ui/yield_in_closure.stderr
@@ -6,13 +6,13 @@ error[E0658]: yield syntax is experimental
   |
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
-error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:202:9: 202:67]`
+error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:201:9: 201:67]`
  --> $DIR/yield_in_closure.rs:6:14
   |
 6 |             .and_then(|v| {
-  |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:202:9: 202:67]`
+  |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:201:9: 201:67]`
   |
-  = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/src/lib.rs:202:9: 202:67]`
+  = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/src/lib.rs:201:9: 201:67]`
 
 Some errors have detailed explanations: E0277, E0658.
 For more information about an error, try `rustc --explain E0277`.


### PR DESCRIPTION
Changes:

* Expand `yield` in internal macro calls (#57)<br class="Apple-interchange-newline">