### PR TITLE
Prepare v0.3.3 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   RUST_BACKTRACE: 1
   # This is the minimum supported Rust version of this crate.
   # When updating this, the reminder to update the minimum supported
-  # Rust version in README.md and .clippy.toml.
+  # Rust version in README.md, Cargo.toml, and .clippy.toml.
   minrust: 1.45.2
 
 jobs:

--- a/async-stream-impl/Cargo.toml
+++ b/async-stream-impl/Cargo.toml
@@ -2,6 +2,7 @@
 name = "async-stream-impl"
 version = "0.3.2"
 edition = "2018"
+rust-version = "1.45"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "proc macros for async-stream crate"

--- a/async-stream-impl/Cargo.toml
+++ b/async-stream-impl/Cargo.toml
@@ -5,8 +5,6 @@ edition = "2018"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "proc macros for async-stream crate"
-documentation = "https://docs.rs/async-stream-impl"
-homepage = "https://github.com/tokio-rs/async-stream"
 repository = "https://github.com/tokio-rs/async-stream"
 
 [lib]

--- a/async-stream-impl/Cargo.toml
+++ b/async-stream-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-stream-impl"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT"

--- a/async-stream/CHANGELOG.md
+++ b/async-stream/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.3.3
+
+* Fix a bug where `yield` and `?` cannot be used on the same line (#66)
+
 # 0.3.2
 
 * Expand `yield` in internal macro calls (#57)

--- a/async-stream/Cargo.toml
+++ b/async-stream/Cargo.toml
@@ -5,6 +5,7 @@ name = "async-stream"
 # - Create git tag
 version = "0.3.2"
 edition = "2018"
+rust-version = "1.45"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "Asynchronous streams using async & await notation"

--- a/async-stream/Cargo.toml
+++ b/async-stream/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-stream"
 # When releasing to crates.io:
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.3.2"
+version = "0.3.3"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT"
@@ -12,7 +12,7 @@ description = "Asynchronous streams using async & await notation"
 repository = "https://github.com/tokio-rs/async-stream"
 
 [dependencies]
-async-stream-impl = { version = "=0.3.2", path = "../async-stream-impl" }
+async-stream-impl = { version = "=0.3.3", path = "../async-stream-impl" }
 futures-core = "0.3"
 
 [dev-dependencies]

--- a/async-stream/Cargo.toml
+++ b/async-stream/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "async-stream"
 # When releasing to crates.io:
-# - Update version number
-#   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
 version = "0.3.2"
@@ -10,10 +8,7 @@ edition = "2018"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "Asynchronous streams using async & await notation"
-documentation = "https://docs.rs/async-stream"
-homepage = "https://github.com/tokio-rs/async-stream"
 repository = "https://github.com/tokio-rs/async-stream"
-readme = "README.md"
 
 [dependencies]
 async-stream-impl = { version = "=0.3.2", path = "../async-stream-impl" }


### PR DESCRIPTION
Changes:

* Fix a bug where `yield` and `?` cannot be used on the same line (#66)
