### PR TITLE
Preserve spans in macro invocations

### DIFF
--- a/async-stream-impl/src/lib.rs
+++ b/async-stream-impl/src/lib.rs
@@ -289,7 +289,9 @@ fn replace_for_await(input: impl IntoIterator<Item = TokenTree>) -> TokenStream2
             }
             TokenTree::Group(group) => {
                 let stream = replace_for_await(group.stream());
-                tokens.push(Group::new(group.delimiter(), stream).into());
+                let mut new_group = Group::new(group.delimiter(), stream);
+                new_group.set_span(group.span());
+                tokens.push(new_group.into());
             }
             _ => tokens.push(token),
         }

--- a/async-stream/tests/spans_preserved.rs
+++ b/async-stream/tests/spans_preserved.rs
@@ -1,0 +1,15 @@
+use async_stream::stream;
+use futures_util::pin_mut;
+use futures_util::stream::StreamExt;
+
+#[tokio::test]
+async fn spans_preserved() {
+    let s = stream! {
+     assert_eq!(line!(), 8);
+    };
+    pin_mut!(s);
+
+    while s.next().await.is_some() {
+        unreachable!();
+    }
+}

--- a/async-stream/tests/try_stream.rs
+++ b/async-stream/tests/try_stream.rs
@@ -66,7 +66,7 @@ async fn multi_try() {
     fn test() -> impl Stream<Item = Result<i32, String>> {
         try_stream! {
             let a = Ok::<_,  String>(Ok::<_,  String>(123))??;
-            for _ in (1..10) {
+            for _ in 1..10 {
                 yield a;
             }
         }

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -12,21 +12,17 @@ error[E0727]: `async` generators are not yet supported
 6 |             yield 123;
   |             ^^^^^^^^^
 
-error[E0271]: type mismatch resolving `<[static generator@$DIR/src/lib.rs:201:9: 201:67] as Generator<ResumeTy>>::Yield == ()`
-  --> tests/ui/yield_in_async.rs:4:5
+error[E0271]: type mismatch resolving `<[static generator@$DIR/tests/ui/yield_in_async.rs:5:23: 7:10] as Generator<ResumeTy>>::Yield == ()`
+  --> tests/ui/yield_in_async.rs:5:23
    |
-4  | /     stream! {
-5  | |         let f = async {
+5  |           let f = async {
+   |  _______________________^
 6  | |             yield 123;
 7  | |         };
-8  | |
-9  | |         let v = f.await;
-10 | |     };
-   | |_____^ expected `()`, found integer
+   | |_________^ expected `()`, found integer
    |
 note: required by a bound in `from_generator`
   --> $RUST/core/src/future/mod.rs
    |
    |     T: Generator<ResumeTy, Yield = ()>,
    |                            ^^^^^^^^^^ required by this bound in `from_generator`
-   = note: this error originates in the macro `stream` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/async-stream/tests/ui/yield_in_closure.stderr
+++ b/async-stream/tests/ui/yield_in_closure.stderr
@@ -6,13 +6,13 @@ error[E0658]: yield syntax is experimental
   |
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
-error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:201:9: 201:67]`
+error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
     --> tests/ui/yield_in_closure.rs:6:14
      |
 6    |             .and_then(|v| {
-     |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/src/lib.rs:201:9: 201:67]`
+     |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
      |
-     = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/src/lib.rs:201:9: 201:67]`
+     = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
 note: required by a bound in `Result::<T, E>::and_then`
     --> $RUST/core/src/result.rs
      |


### PR DESCRIPTION
Previously, `#[track_caller]` functions (such as used by `panic!`) called within `stream!` invocations would resolve to the macro call site. This PR preserves more span information, so these should now resolve to a more specific location within the user's code.