### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/async-stream/src/async_stream.rs
+++ b/async-stream/src/async_stream.rs
@@ -40,8 +40,8 @@ where
     type Item = T;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        unsafe {
-            let me = Pin::get_unchecked_mut(self);
+        
+            let me = unsafe { Pin::get_unchecked_mut(self) };
 
             if me.done {
                 return Poll::Ready(None);
@@ -50,7 +50,7 @@ where
             let mut dst = None;
             let res = {
                 let _enter = me.rx.enter(&mut dst);
-                Pin::new_unchecked(&mut me.generator).poll(cx)
+                unsafe { Pin::new_unchecked(&mut me.generator).poll(cx) }
             };
 
             me.done = res.is_ready();
@@ -64,7 +64,7 @@ where
             } else {
                 Poll::Pending
             }
-        }
+        
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/async-stream/src/yielder.rs
+++ b/async-stream/src/yielder.rs
@@ -53,9 +53,9 @@ impl<T> Future for Send<T> {
             return Poll::Ready(());
         }
 
-        STORE.with(|cell| unsafe {
+        STORE.with(|cell| {
             let ptr = cell.get() as *mut Option<T>;
-            let option_ref = ptr.as_mut().expect("invalid usage");
+            let option_ref = unsafe { ptr.as_mut() }.expect("invalid usage");
 
             if option_ref.is_none() {
                 *option_ref = self.value.take();


### PR DESCRIPTION
In these function you use the unsafe keyword for almost the entrie function body. 
We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 
Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 