### PR TITLE
Reduce `unsafe` usage

### DIFF
--- a/async-stream/Cargo.toml
+++ b/async-stream/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/tokio-rs/async-stream"
 [dependencies]
 async-stream-impl = { version = "=0.3.3", path = "../async-stream-impl" }
 futures-core = "0.3"
+pin-project-lite = "0.2"
 
 [dev-dependencies]
 futures-util = "0.3"

--- a/async-stream/src/yielder.rs
+++ b/async-stream/src/yielder.rs
@@ -53,9 +53,9 @@ impl<T> Future for Send<T> {
             return Poll::Ready(());
         }
 
-        STORE.with(|cell| unsafe {
+        STORE.with(|cell| {
             let ptr = cell.get() as *mut Option<T>;
-            let option_ref = ptr.as_mut().expect("invalid usage");
+            let option_ref = unsafe { ptr.as_mut() }.expect("invalid usage");
 
             if option_ref.is_none() {
                 *option_ref = self.value.take();


### PR DESCRIPTION
Supersedes #76.

Addresses https://github.com/tokio-rs/async-stream/pull/76#discussion_r904686727 by removing `unsafe` in `
poll_next()` by using `pin-project-lite`.

Closes #76