### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       - run: cargo test --all-features
 
   minrust:
+    env:
+      CARGO_NET_GIT_FETCH_WITH_CLI: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -13,16 +13,12 @@ error[E0727]: `async` generators are not yet supported
   |             ^^^^^^^^^
 
 error[E0271]: type mismatch resolving `<[static generator@$DIR/tests/ui/yield_in_async.rs:5:23: 7:10] as Generator<ResumeTy>>::Yield == ()`
-  --> tests/ui/yield_in_async.rs:5:23
-   |
-5  |           let f = async {
-   |  _______________________^
-6  | |             yield 123;
-7  | |         };
-   | |_________^ expected `()`, found integer
-   |
-note: required by a bound in `from_generator`
-  --> $RUST/core/src/future/mod.rs
-   |
-   |     T: Generator<ResumeTy, Yield = ()>,
-   |                            ^^^^^^^^^^ required by this bound in `from_generator`
+ --> tests/ui/yield_in_async.rs:5:23
+  |
+5 |           let f = async {
+  |  _______________________^
+6 | |             yield 123;
+7 | |         };
+  | |_________^ expected `()`, found integer
+  |
+note: required by a bound in `std::future::from_generator`

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -13,12 +13,16 @@ error[E0727]: `async` generators are not yet supported
   |             ^^^^^^^^^
 
 error[E0271]: type mismatch resolving `<[static generator@$DIR/tests/ui/yield_in_async.rs:5:23: 7:10] as Generator<ResumeTy>>::Yield == ()`
- --> tests/ui/yield_in_async.rs:5:23
-  |
-5 |           let f = async {
-  |  _______________________^
-6 | |             yield 123;
-7 | |         };
-  | |_________^ expected `()`, found integer
-  |
+  --> tests/ui/yield_in_async.rs:5:23
+   |
+5  |           let f = async {
+   |  _______________________^
+6  | |             yield 123;
+7  | |         };
+   | |_________^ expected `()`, found integer
+   |
 note: required by a bound in `std::future::from_generator`
+  --> $RUST/core/src/future/mod.rs
+   |
+   |     T: Generator<ResumeTy, Yield = ()>,
+   |                            ^^^^^^^^^^ required by this bound in `std::future::from_generator`

--- a/async-stream/tests/ui/yield_in_closure.stderr
+++ b/async-stream/tests/ui/yield_in_closure.stderr
@@ -7,14 +7,10 @@ error[E0658]: yield syntax is experimental
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
 error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
-    --> tests/ui/yield_in_closure.rs:6:14
-     |
-6    |             .and_then(|v| {
-     |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
-     |
-     = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
+ --> tests/ui/yield_in_closure.rs:6:14
+  |
+6 |             .and_then(|v| {
+  |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
+  |
+  = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
 note: required by a bound in `Result::<T, E>::and_then`
-    --> $RUST/core/src/result.rs
-     |
-     |     pub fn and_then<U, F: FnOnce(T) -> Result<U, E>>(self, op: F) -> Result<U, E> {
-     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Result::<T, E>::and_then`

--- a/async-stream/tests/ui/yield_in_closure.stderr
+++ b/async-stream/tests/ui/yield_in_closure.stderr
@@ -7,10 +7,14 @@ error[E0658]: yield syntax is experimental
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
 error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
- --> tests/ui/yield_in_closure.rs:6:14
-  |
-6 |             .and_then(|v| {
-  |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
-  |
-  = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
+    --> tests/ui/yield_in_closure.rs:6:14
+     |
+6    |             .and_then(|v| {
+     |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
+     |
+     = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
 note: required by a bound in `Result::<T, E>::and_then`
+    --> $RUST/core/src/result.rs
+     |
+     |     pub fn and_then<U, F: FnOnce(T) -> Result<U, E>>(self, op: F) -> Result<U, E> {
+     |                           ^^^^^^^^^^^^^^^^^^^^^^^^^ required by this bound in `Result::<T, E>::and_then`


### PR DESCRIPTION
This fixes:
- CI on 1.45 is broken due to a recent GitHub API change: https://github.com/tokio-rs/async-stream/runs/7823467805?check_suite_focus=true
- ui test is also broken due to a diagnostics change in new rustc. https://github.com/tokio-rs/async-stream/runs/7823467856?check_suite_focus=true