### PR TITLE
Fix CI failure

### DIFF
--- a/async-stream/tests/ui/yield_in_closure.stderr
+++ b/async-stream/tests/ui/yield_in_closure.stderr
@@ -6,13 +6,13 @@ error[E0658]: yield syntax is experimental
   |
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
-error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
+error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26]`
     --> tests/ui/yield_in_closure.rs:6:14
      |
 6    |             .and_then(|v| {
-     |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
+     |              ^^^^^^^^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26]`
      |
-     = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 9:14]`
+     = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26]`
 note: required by a bound in `Result::<T, E>::and_then`
     --> $RUST/core/src/result.rs
      |


### PR DESCRIPTION
UI test is currently broken due to a diagnostics change in rust 1.64: https://github.com/tokio-rs/async-stream/actions/runs/3110119539/jobs/5040982223