### PR TITLE
Prepare v0.3.4 release

### DIFF
--- a/async-stream-impl/Cargo.toml
+++ b/async-stream-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-stream-impl"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT"

--- a/async-stream/CHANGELOG.md
+++ b/async-stream/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.4
+
+* Improve support for `#[track_caller]` (#72)
+* Reduce unsafe code (#77)
+
 # 0.3.3
 
 * Fix a bug where `yield` and `?` cannot be used on the same line (#66)

--- a/async-stream/Cargo.toml
+++ b/async-stream/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-stream"
 # When releasing to crates.io:
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.3.3"
+version = "0.3.4"
 edition = "2018"
 rust-version = "1.45"
 license = "MIT"
@@ -12,7 +12,7 @@ description = "Asynchronous streams using async & await notation"
 repository = "https://github.com/tokio-rs/async-stream"
 
 [dependencies]
-async-stream-impl = { version = "=0.3.3", path = "../async-stream-impl" }
+async-stream-impl = { version = "=0.3.4", path = "../async-stream-impl" }
 futures-core = "0.3"
 pin-project-lite = "0.2"
 

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -12,17 +12,8 @@ error[E0727]: `async` generators are not yet supported
 6 |             yield 123;
   |             ^^^^^^^^^
 
-error[E0271]: type mismatch resolving `<[static generator@$DIR/tests/ui/yield_in_async.rs:5:23: 7:10] as Generator<ResumeTy>>::Yield == ()`
-  --> tests/ui/yield_in_async.rs:5:23
-   |
-5  |           let f = async {
-   |  _______________________^
-6  | |             yield 123;
-7  | |         };
-   | |_________^ expected `()`, found integer
-   |
-note: required by a bound in `std::future::from_generator`
-  --> $RUST/core/src/future/mod.rs
-   |
-   |     T: Generator<ResumeTy, Yield = ()>,
-   |                            ^^^^^^^^^^ required by this bound in `std::future::from_generator`
+error[E0308]: mismatched types
+ --> tests/ui/yield_in_async.rs:6:19
+  |
+6 |             yield 123;
+  |                   ^^^ expected `()`, found integer


### PR DESCRIPTION
Changes:
* Improve support for `#[track_caller]` (#72)
* Reduce unsafe code (#77)

Closes #90 