### PR TITLE
Update to syn-2

### DIFF
--- a/async-stream-impl/Cargo.toml
+++ b/async-stream-impl/Cargo.toml
@@ -13,7 +13,7 @@ proc-macro = true
 
 [dependencies]
 proc-macro2 = "1"
-syn = { version = "1", features = ["full", "visit-mut"] }
+syn = { version = "2", features = ["full", "visit-mut"] }
 quote = "1"
 
 [dev-dependencies]

--- a/async-stream-impl/src/lib.rs
+++ b/async-stream-impl/src/lib.rs
@@ -147,7 +147,7 @@ impl VisitMut for Scrub<'_> {
             syn::Expr::ForLoop(expr) => {
                 syn::visit_mut::visit_expr_for_loop_mut(self, expr);
                 // TODO: Should we allow other attributes?
-                if expr.attrs.len() != 1 || !expr.attrs[0].path.is_ident("await") {
+                if expr.attrs.len() != 1 || !expr.attrs[0].path().is_ident("await_") {
                     return;
                 }
                 let syn::ExprForLoop {
@@ -160,7 +160,7 @@ impl VisitMut for Scrub<'_> {
                 } = expr;
 
                 let attr = attrs.pop().unwrap();
-                if let Err(e) = syn::parse2::<syn::parse::Nothing>(attr.tokens) {
+                if let Err(e) = attr.meta.require_path_only() {
                     *i = syn::parse2(e.to_compile_error()).unwrap();
                     return;
                 }
@@ -280,7 +280,7 @@ fn replace_for_await(input: impl IntoIterator<Item = TokenTree>) -> TokenStream2
             TokenTree::Ident(ident) => {
                 match input.peek() {
                     Some(TokenTree::Ident(next)) if ident == "for" && next == "await" => {
-                        tokens.extend(quote!(#[#next]));
+                        tokens.extend(quote!(#[await_]));
                         let _ = input.next();
                     }
                     _ => {}


### PR DESCRIPTION
Potentially a breaking change if users were directly using `#[await]`. `syn` will no longer accept as legal attributes whose paths are keywords. Here, we work around it by translating `for await` to `#[await_] for`.