### PR TITLE
Bump MSRV to 1.56

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
   # This is the minimum supported Rust version of this crate.
   # When updating this, the reminder to update the minimum supported
   # Rust version in README.md, Cargo.toml, and .clippy.toml.
-  minrust: 1.45.2
+  minrust: '1.56'
 
 jobs:
   test:

--- a/async-stream-impl/Cargo.toml
+++ b/async-stream-impl/Cargo.toml
@@ -2,7 +2,7 @@
 name = "async-stream-impl"
 version = "0.3.4"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "proc macros for async-stream crate"

--- a/async-stream/Cargo.toml
+++ b/async-stream/Cargo.toml
@@ -5,7 +5,7 @@ name = "async-stream"
 # - Create git tag
 version = "0.3.4"
 edition = "2018"
-rust-version = "1.45"
+rust-version = "1.56"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]
 description = "Asynchronous streams using async & await notation"

--- a/async-stream/README.md
+++ b/async-stream/README.md
@@ -152,7 +152,7 @@ caller.
 
 ## Supported Rust Versions
 
-`async-stream` is built against the latest stable release. The minimum supported version is 1.45 due to [function-like procedural macros in expression, pattern, and statement positions](https://blog.rust-lang.org/2020/07/16/Rust-1.45.0.html#stabilizing-function-like-procedural-macros-in-expressions-patterns-and-statements).
+The current minimum supported Rust version is 1.56.
 
 ## License
 


### PR DESCRIPTION
syn 2.0 requires 1.56.

Unblock #93