### PR TITLE
Prepare v0.3.5 release

### DIFF
--- a/async-stream-impl/Cargo.toml
+++ b/async-stream-impl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-stream-impl"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2018"
 rust-version = "1.56"
 license = "MIT"

--- a/async-stream/CHANGELOG.md
+++ b/async-stream/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.3.5
+
+* Update to syn 2.0 (#93)
+* Bump MSRV to 1.56 (#97)
+
 # 0.3.4
 
 * Improve support for `#[track_caller]` (#72)

--- a/async-stream/Cargo.toml
+++ b/async-stream/Cargo.toml
@@ -3,7 +3,7 @@ name = "async-stream"
 # When releasing to crates.io:
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.3.4"
+version = "0.3.5"
 edition = "2018"
 rust-version = "1.56"
 license = "MIT"
@@ -12,7 +12,7 @@ description = "Asynchronous streams using async & await notation"
 repository = "https://github.com/tokio-rs/async-stream"
 
 [dependencies]
-async-stream-impl = { version = "=0.3.4", path = "../async-stream-impl" }
+async-stream-impl = { version = "=0.3.5", path = "../async-stream-impl" }
 futures-core = "0.3"
 pin-project-lite = "0.2"
 


### PR DESCRIPTION
Changes:

* Update to syn 2.0 (#93)
* Bump MSRV to 1.56 (#97)