### PR TITLE
Upgrade to 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
     "async-stream",
     "async-stream-impl",

--- a/async-stream-impl/Cargo.toml
+++ b/async-stream-impl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "async-stream-impl"
 version = "0.3.5"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]

--- a/async-stream/Cargo.toml
+++ b/async-stream/Cargo.toml
@@ -4,7 +4,7 @@ name = "async-stream"
 # - Update CHANGELOG.md
 # - Create git tag
 version = "0.3.5"
-edition = "2018"
+edition = "2021"
 rust-version = "1.56"
 license = "MIT"
 authors = ["Carl Lerche <me@carllerche.com>"]

--- a/async-stream/tests/reexporter/Cargo.toml
+++ b/async-stream/tests/reexporter/Cargo.toml
@@ -2,7 +2,7 @@
 name = "reexporter"
 version = "0.0.0"
 authors = []
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]

--- a/async-stream/tests/test-reexport/Cargo.toml
+++ b/async-stream/tests/test-reexport/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test-reexport"
 version = "0.0.0"
 authors = []
-edition = "2018"
+edition = "2021"
 publish = false
 
 [dependencies]


### PR DESCRIPTION
Since #97, our MSRV is 1.56, so we can safely upgrade to 2021 edition.