### PR TITLE
Update CI config and fix CI failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
     branches:
       - master
   schedule:
-    - cron: '0 2 * * *'
+    - cron: '0 2 * * 0'
 
 env:
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update stable
       - run: rustup component add rust-src
@@ -33,7 +33,7 @@ jobs:
       CARGO_NET_GIT_FETCH_WITH_CLI: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update ${{ env.minrust }} && rustup default ${{ env.minrust }}
       - run: cargo build --all-features
@@ -41,7 +41,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update stable
       - run: cargo fmt --all -- --check
@@ -49,7 +49,7 @@ jobs:
   clippy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update stable
       - run: cargo clippy --all-features
@@ -57,7 +57,7 @@ jobs:
   docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update nightly && rustup default nightly
       - run: cargo doc --no-deps --all-features

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Rust
         run: rustup update stable
-      - run: cargo fmt --all -- --check
+      - run: cargo fmt --all --check
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,6 @@ on:
 env:
   RUSTFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  # This is the minimum supported Rust version of this crate.
-  # When updating this, the reminder to update the minimum supported
-  # Rust version in README.md, Cargo.toml, and .clippy.toml.
-  minrust: '1.56'
 
 jobs:
   test:
@@ -29,14 +25,12 @@ jobs:
       - run: cargo test --all-features
 
   minrust:
-    env:
-      CARGO_NET_GIT_FETCH_WITH_CLI: true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Install Rust
-        run: rustup update ${{ env.minrust }} && rustup default ${{ env.minrust }}
-      - run: cargo build --all-features
+      - name: Install cargo-hack
+        uses: taiki-e/install-action@cargo-hack
+      - run: cargo hack build --all-features --ignore-private --rust-version
 
   fmt:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.repository_owner == 'tokio-rs'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: taiki-e/create-gh-release-action@v1
         with:
           changelog: async-stream/CHANGELOG.md

--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -6,7 +6,7 @@ error[E0658]: yield syntax is experimental
   |
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
-error[E0727]: `async` generators are not yet supported
+error[E0727]: `async` coroutines are not yet supported
  --> tests/ui/yield_in_async.rs:6:13
   |
 6 |             yield 123;

--- a/async-stream/tests/ui/yield_in_closure.stderr
+++ b/async-stream/tests/ui/yield_in_closure.stderr
@@ -6,7 +6,7 @@ error[E0658]: yield syntax is experimental
   |
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
-error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26]`
+error[E0277]: expected a `FnOnce(&str)` closure, found `{coroutine@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26}`
  --> tests/ui/yield_in_closure.rs:6:23
   |
 6 |               .and_then(|v| {
@@ -16,9 +16,9 @@ error[E0277]: expected a `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests
 7 | |                 yield v;
 8 | |                 Ok(())
 9 | |             });
-  | |_____________^ expected an `FnOnce<(&str,)>` closure, found `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26]`
+  | |_____________^ expected an `FnOnce(&str)` closure, found `{coroutine@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26}`
   |
-  = help: the trait `FnOnce<(&str,)>` is not implemented for `[generator@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26]`
+  = help: the trait `FnOnce<(&str,)>` is not implemented for `{coroutine@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26}`
 note: required by a bound in `Result::<T, E>::and_then`
  --> $RUST/core/src/result.rs
   |

--- a/async-stream/tests/ui/yield_in_nested_fn.stderr
+++ b/async-stream/tests/ui/yield_in_nested_fn.stderr
@@ -6,7 +6,7 @@ error[E0658]: yield syntax is experimental
   |
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
-error[E0627]: yield expression outside of generator literal
+error[E0627]: yield expression outside of coroutine literal
  --> tests/ui/yield_in_nested_fn.rs:6:13
   |
 6 |             yield "hello";


### PR DESCRIPTION
- Update actions/checkout action to v4 
- Reduce frequency of scheduled job (daily -> weekly)
  We use stable toolchain in most cases, so we usually don't need to check it every day.
- Remove no longer needed argument for cargo fmt
- Use cargo-hack's --rust-version flag for minrust job
  This respects rust-version field in Cargo.toml, so it removes the need to manage MSRV in both the CI file and Cargo.toml.
- Update ui test output for Rust 1.75
  This fixes CI failure: https://github.com/tokio-rs/async-stream/actions/runs/7428797081/job/20216569930