### PR TITLE
Fix CI failure

### DIFF
--- a/async-stream/tests/ui/yield_in_async.stderr
+++ b/async-stream/tests/ui/yield_in_async.stderr
@@ -11,9 +11,3 @@ error[E0727]: `async` coroutines are not yet supported
   |
 6 |             yield 123;
   |             ^^^^^^^^^
-
-error[E0308]: mismatched types
- --> tests/ui/yield_in_async.rs:6:19
-  |
-6 |             yield 123;
-  |                   ^^^ expected `()`, found integer


### PR DESCRIPTION
Fix ui test failure on Rust 1.76: https://github.com/tokio-rs/async-stream/actions/runs/8127087685/job/22211533379