### PR TITLE
Fix CI failures

### DIFF
--- a/async-stream-impl/src/lib.rs
+++ b/async-stream-impl/src/lib.rs
@@ -65,7 +65,7 @@ fn visit_token_stream_impl(
                         tokens = rest.into_iter().peekable();
                     }
                     Err(e) => {
-                        out.append_all(&mut e.to_compile_error().into_iter());
+                        out.append_all(e.to_compile_error().into_iter());
                         *modified = true;
                         return;
                     }

--- a/async-stream/tests/ui/yield_in_closure.stderr
+++ b/async-stream/tests/ui/yield_in_closure.stderr
@@ -6,6 +6,17 @@ error[E0658]: yield syntax is experimental
   |
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+ --> tests/ui/yield_in_closure.rs:7:17
+  |
+7 |                 yield v;
+  |                 ^^^^^^^
+  |
+help: use `#[coroutine]` to make this closure a coroutine
+  |
+6 |             .and_then(#[coroutine] |v| {
+  |                       ++++++++++++
+
 error[E0277]: expected a `FnOnce(&str)` closure, found `{coroutine@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26}`
  --> tests/ui/yield_in_closure.rs:6:23
   |
@@ -18,7 +29,7 @@ error[E0277]: expected a `FnOnce(&str)` closure, found `{coroutine@$DIR/tests/ui
 9 | |             });
   | |_____________^ expected an `FnOnce(&str)` closure, found `{coroutine@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26}`
   |
-  = help: the trait `FnOnce<(&str,)>` is not implemented for `{coroutine@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26}`
+  = help: the trait `FnOnce(&str)` is not implemented for `{coroutine@$DIR/tests/ui/yield_in_closure.rs:6:23: 6:26}`
 note: required by a bound in `Result::<T, E>::and_then`
  --> $RUST/core/src/result.rs
   |

--- a/async-stream/tests/ui/yield_in_nested_fn.stderr
+++ b/async-stream/tests/ui/yield_in_nested_fn.stderr
@@ -6,6 +6,17 @@ error[E0658]: yield syntax is experimental
   |
   = note: see issue #43122 <https://github.com/rust-lang/rust/issues/43122> for more information
 
+error: `yield` can only be used in `#[coroutine]` closures, or `gen` blocks
+ --> tests/ui/yield_in_nested_fn.rs:6:13
+  |
+6 |             yield "hello";
+  |             ^^^^^^^^^^^^^
+  |
+help: use `#[coroutine]` to make this closure a coroutine
+  |
+5 |         #[coroutine] fn foo() {
+  |         ++++++++++++
+
 error[E0627]: yield expression outside of coroutine literal
  --> tests/ui/yield_in_nested_fn.rs:6:13
   |


### PR DESCRIPTION
Fix new clippy warning: https://github.com/tokio-rs/async-stream/actions/runs/10867400910/job/30156109445
And fix ui test failure: https://github.com/tokio-rs/async-stream/actions/runs/10867400910/job/30156109179