### PR TITLE
Fix newly added clippy warning

### DIFF
--- a/async-stream/src/yielder.rs
+++ b/async-stream/src/yielder.rs
@@ -87,7 +87,7 @@ impl<T> Receiver<T> {
 
 // ===== impl Enter =====
 
-impl<'a, T> Drop for Enter<'a, T> {
+impl<T> Drop for Enter<'_, T> {
     fn drop(&mut self) {
         STORE.with(|cell| cell.set(self.prev));
     }

--- a/async-stream/tests/stream.rs
+++ b/async-stream/tests/stream.rs
@@ -161,7 +161,7 @@ async fn borrow_self() {
     struct Data(String);
 
     impl Data {
-        fn stream<'a>(&'a self) -> impl Stream<Item = &str> + 'a {
+        fn stream(&self) -> impl Stream<Item = &str> + '_ {
             stream! {
                 yield &self.0[..];
             }


### PR DESCRIPTION
Fixes clippy warning added in Rust 1.83.

See commit message for the content of warning.